### PR TITLE
chore: Use --no-cache-dir flag to pip in Dockerfiles, to save space

### DIFF
--- a/images/worker-fedora-34-x86_64/Dockerfile
+++ b/images/worker-fedora-34-x86_64/Dockerfile
@@ -21,7 +21,7 @@ RUN dnf install -y \
 	ruby-devel \
 	which \
 	&& dnf clean all \
-	&& pip3 install \
+	&& pip3 install --no-cache-dir \
 		agithub==2.2.2 \
 		buildbot-worker==3.1.1 \
 	&& gem install fpm -v 1.12.0 --no-document \

--- a/images/worker-manylinux-x86_64/Dockerfile
+++ b/images/worker-manylinux-x86_64/Dockerfile
@@ -9,7 +9,7 @@ RUN \
 		bison \
 		flex \
 	&& yum -y clean all \
-	&& pip3 install \
+	&& pip3 install --no-cache-dir \
 		agithub==2.2.2 \
 		buildbot-worker==3.1.1 \
 		requests==2.25.1 \

--- a/images/worker-ubuntu-20.04-x86_64/Dockerfile
+++ b/images/worker-ubuntu-20.04-x86_64/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update \
 	&& rm -r 5.15.2 \
 	&& sed -i -e "s,QT_EDITION = Enterprise,QT_EDITION = OpenSource," -e "/QT_LICHECK = /d" mkspecs/qconfig.pri \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& pip3 install \
+	&& pip3 install --no-cache-dir \
 		agithub==2.2.2 \
 		buildbot-worker==3.1.1 \
 	&& gem install fpm -v 1.12.0 --no-document \

--- a/images/worker-ubuntu-21.04-x86_64/Dockerfile
+++ b/images/worker-ubuntu-21.04-x86_64/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
 	&& dpkg-reconfigure --frontend=noninteractive locales \
 	&& update-locale LANG=en_US.UTF-8 \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& pip3 install \
+	&& pip3 install --no-cache-dir \
 		agithub==2.2.2 \
 		buildbot-worker==3.1.1 \
 	&& gem install fpm -v 1.12.0 --no-document \


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>